### PR TITLE
Add option for command timeouts

### DIFF
--- a/src/DotPulsar/Internal/Awaiter.cs
+++ b/src/DotPulsar/Internal/Awaiter.cs
@@ -79,6 +79,11 @@ namespace DotPulsar.Internal
                             // Make sure it's either the same item we checked, or we're too late to put it back
                             if ((maybeExpiredItem == itemToCheck.Value) || !_items.TryAdd(itemToCheck.Key, maybeExpiredItem))
                             {
+                                // In the implementation as of this code change, we do not expect to ever actually hit
+                                // either of these conditions, because Awaiters are unique to a Connection, and commands
+                                // outside of Connect have unique request IDs within a Connection.
+                                // This code is only for safety.  In case these assumptions are invalidated later,
+                                // we will cancel this task because it can no longer be tracked correctly due to a race.
                                 maybeExpiredItem.tcs.TrySetCanceled();
                             }
                         }


### PR DESCRIPTION
# Summary

This PR attempts to add an optional command timeout to all commands sent to pulsar that wait for a response.  The result of a command after the timeout has occurred should be considered an indeterminate state (the broker may yet still act upon it), but this is preferable to any given request hanging indefinitely until the connection is severed.  Timeout resolution is currently low in order to keep overhead down, and fixed in order to keep change complexity down.