### PR TITLE
Fix memory leak introduced by AsyncLock change

### DIFF
--- a/src/DotPulsar/Internal/AsyncLock.cs
+++ b/src/DotPulsar/Internal/AsyncLock.cs
@@ -38,8 +38,15 @@ namespace DotPulsar.Internal
             ThrowIfDisposed();
 
             var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_disposing.Token, cancellationToken);
-            await _semaphoreSlim.WaitAsync(linkedTokenSource.Token);
-            return _releaser;
+            try
+            {
+                await _semaphoreSlim.WaitAsync(linkedTokenSource.Token);
+                return _releaser;
+            }
+            finally
+            {
+                linkedTokenSource.Dispose();
+            }
         }
 
         public ValueTask DisposeAsync()


### PR DESCRIPTION
I introduced a memory leak by creating linked cancellation token sources but not disposing of them.  They register a callback with the parent token source, so if not disposed they will build up a pile of callback references.  Disposing of the linked token source will deregister any callbacks created by the linking.
