### PR TITLE
Fix off-by-one error in stream parser

### DIFF
--- a/src/DotPulsar/Internal/Awaiter.cs
+++ b/src/DotPulsar/Internal/Awaiter.cs
@@ -47,10 +47,14 @@ namespace DotPulsar.Internal
             return tcs.Task;
         }
 
-        public void SetResult(T item, TResult result)
+        public bool SetResult(T item, TResult result)
         {
             if (_items.TryRemove(item, out var tuple))
+            {
                 tuple.tcs.SetResult(result);
+                return true;
+            }
+            return false;
         }
 
         public void Fault(T item, Exception exceptionToRelay)

--- a/src/DotPulsar/Internal/Extensions/ReadOnlySequenceExtensions.cs
+++ b/src/DotPulsar/Internal/Extensions/ReadOnlySequenceExtensions.cs
@@ -88,7 +88,7 @@ namespace DotPulsar.Internal.Extensions
                     }
                 }
 
-                if (read == 3)
+                if (read == 4)
                     break;
 
                 start = 0;

--- a/src/DotPulsar/Internal/RequestResponseHandler.cs
+++ b/src/DotPulsar/Internal/RequestResponseHandler.cs
@@ -76,7 +76,14 @@ namespace DotPulsar.Internal
                         messages.TryRemove(identifier, out _);
                     }
                 }
-                _responses.SetResult(identifier, command);
+                if (!_responses.SetResult(identifier, command))
+                {
+                    _logger.Info(nameof(RequestResponseHandler), nameof(Incoming), "Received response for request of {0} - {1} on connection {2} but the request was not found; either the request has failed locally or the incoming message is corrupt", command.CommandType, identifier, _connectionId);
+                }
+            }
+            else
+            {
+                _logger.Error(nameof(RequestResponseHandler), nameof(Incoming), "Received a response {0} for a request with a null identifier on connection {1}", command.CommandType, _connectionId);
             }
         }
 

--- a/tests/DotPulsar.Tests/Internal/Extensions/ReadOnlySequenceExtensionsTests.cs
+++ b/tests/DotPulsar.Tests/Internal/Extensions/ReadOnlySequenceExtensionsTests.cs
@@ -127,17 +127,25 @@ namespace DotPulsar.Tests.Internal.Extensions
             actual.Should().Be(expected);
         }
 
-        [Fact]
-        public void ReadUInt32_GivenSequenceWithMultipleSegments_ShouldGiveExceptedResult()
+        [Theory]
+        [InlineData(new byte[] {}, new byte[] { 0x00, 0x01, 0x02, 0x03 })]
+        [InlineData(new byte[] { 0x00 }, new byte[] { 0x01, 0x02, 0x03 })]
+        [InlineData(new byte[] { 0x00, 0x01 }, new byte[] { 0x02, 0x03 })]
+        [InlineData(new byte[] { 0x00, 0x01, 0x02 }, new byte[] { 0x03 })]
+        [InlineData(new byte[] { 0x00, 0x01, 0x02, 0x03 }, new byte[] {})]
+        public void ReadUInt32_GivenSequenceWithMultipleSegments_ShouldGiveExceptedResult(params byte[][] testPath)
         {
             //Arrange
-            var sequence = new SequenceBuilder<byte>().Append(new byte[] { 0x00, 0x01 }).Append(new byte[] { 0x02, 0x03 }).Build();
+            var sequenceBuilder = new SequenceBuilder<byte>();
+            foreach (var array in testPath)
+                sequenceBuilder.Append(array);
+            var sequence = sequenceBuilder.Build();
 
             //Act
             var actual = sequence.ReadUInt32(0, true);
 
             //Assert
-            const uint expected = 66051;
+            const uint expected = 0x00010203;
             actual.Should().Be(expected);
         }
 

--- a/tests/DotPulsar.Tests/Internal/Extensions/ReadOnlySequenceExtensionsTests.cs
+++ b/tests/DotPulsar.Tests/Internal/Extensions/ReadOnlySequenceExtensionsTests.cs
@@ -126,7 +126,7 @@ namespace DotPulsar.Tests.Internal.Extensions
             const uint expected = 66051;
             actual.Should().Be(expected);
         }
-
+        #pragma warning disable xUnit1025 // Miscoded warning can't tell these are all different
         [Theory]
         [InlineData(new byte[] {}, new byte[] { 0x02, 0x03, 0x04, 0x05 })]
         [InlineData(new byte[] { 0x02 }, new byte[] { 0x03, 0x04, 0x05 })]
@@ -143,6 +143,7 @@ namespace DotPulsar.Tests.Internal.Extensions
         [InlineData(new byte[] { 0x02, 0x03, 0x04 }, new byte[] { 0x05, 0x09 })]
         [InlineData(new byte[] { 0x02 }, new byte[] { 0x03, 0x04, 0x05 }, new byte[] { 0x09 })]
         [InlineData(new byte[] { 0x02 }, new byte[] { 0x03 }, new byte[] { 0x04, 0x05 }, new byte[] { 0x09 })]
+        #pragma warning restore xUnit1025 // InlineData should be unique within the Theory it belongs to
         public void ReadUInt32_GivenSequenceWithMultipleSegments_ShouldGiveExceptedResult(params byte[][] testPath)
         {
             //Arrange

--- a/tests/DotPulsar.Tests/Internal/Extensions/ReadOnlySequenceExtensionsTests.cs
+++ b/tests/DotPulsar.Tests/Internal/Extensions/ReadOnlySequenceExtensionsTests.cs
@@ -128,11 +128,21 @@ namespace DotPulsar.Tests.Internal.Extensions
         }
 
         [Theory]
-        [InlineData(new byte[] {}, new byte[] { 0x00, 0x01, 0x02, 0x03 })]
-        [InlineData(new byte[] { 0x00 }, new byte[] { 0x01, 0x02, 0x03 })]
-        [InlineData(new byte[] { 0x00, 0x01 }, new byte[] { 0x02, 0x03 })]
-        [InlineData(new byte[] { 0x00, 0x01, 0x02 }, new byte[] { 0x03 })]
-        [InlineData(new byte[] { 0x00, 0x01, 0x02, 0x03 }, new byte[] {})]
+        [InlineData(new byte[] {}, new byte[] { 0x02, 0x03, 0x04, 0x05 })]
+        [InlineData(new byte[] { 0x02 }, new byte[] { 0x03, 0x04, 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03 }, new byte[] { 0x04, 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03, 0x04 }, new byte[] { 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03, 0x04, 0x05 }, new byte[] {})]
+        [InlineData(new byte[] { 0x02 }, new byte[] {}, new byte[] { 0x03, 0x04, 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03 }, new byte[] {}, new byte[] { 0x04, 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03, 0x04 }, new byte[] {}, new byte[] { 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03 }, new byte[] { 0x04 }, new byte[] { 0x05 })]
+        [InlineData(new byte[] { 0x02 }, new byte[] { 0x03, 0x04 }, new byte[] { 0x05 })]
+        [InlineData(new byte[] { 0x02 }, new byte[] { 0x03 }, new byte[] { 0x04, 0x05 })]
+        [InlineData(new byte[] { 0x02 }, new byte[] { 0x03 }, new byte[] { 0x04 }, new byte[] { 0x05 })]
+        [InlineData(new byte[] { 0x02, 0x03, 0x04 }, new byte[] { 0x05, 0x09 })]
+        [InlineData(new byte[] { 0x02 }, new byte[] { 0x03, 0x04, 0x05 }, new byte[] { 0x09 })]
+        [InlineData(new byte[] { 0x02 }, new byte[] { 0x03 }, new byte[] { 0x04, 0x05 }, new byte[] { 0x09 })]
         public void ReadUInt32_GivenSequenceWithMultipleSegments_ShouldGiveExceptedResult(params byte[][] testPath)
         {
             //Arrange
@@ -145,24 +155,27 @@ namespace DotPulsar.Tests.Internal.Extensions
             var actual = sequence.ReadUInt32(0, true);
 
             //Assert
-            const uint expected = 0x00010203;
+            const uint expected = 0x02030405;
             actual.Should().Be(expected);
         }
 
-        [Fact]
-        public void ReadUInt32_GivenSequenceWithMultipleSegmentsAndNonZeroStart_ShouldGiveExceptedResult()
+        [Theory]
+        [InlineData(2, new byte[] { 0x09, 0x09, 0x02 }, new byte[] { 0x03, 0x04, 0x05 }, new byte[] { 0x09, 0x09, 0x09 })]
+        [InlineData(3, new byte[] { 0x09, 0x09, 0x09 }, new byte[] { 0x02, 0x03, 0x04 }, new byte[] { 0x05, 0x09, 0x09 })]
+        [InlineData(4, new byte[] { 0x09, 0x09, 0x09 }, new byte[] { 0x09, 0x02, 0x03 }, new byte[] { 0x04, 0x05, 0x09 })]
+        public void ReadUInt32_GivenSequenceWithMultipleSegmentsAndNonZeroStart_ShouldGiveExceptedResult(long start, params byte[][] testPath)
         {
             //Arrange
-            var sequence = new SequenceBuilder<byte>()
-                .Append(new byte[] { 0x09, 0x09, 0x09 })
-                .Append(new byte[] { 0x09, 0x00, 0x01 })
-                .Append(new byte[] { 0x02, 0x03 }).Build();
+            var sequenceBuilder = new SequenceBuilder<byte>();
+            foreach (var array in testPath)
+                sequenceBuilder.Append(array);
+            var sequence = sequenceBuilder.Build();
 
             //Act
-            var actual = sequence.ReadUInt32(4, true);
+            var actual = sequence.ReadUInt32(start, true);
 
             //Assert
-            const uint expected = 66051;
+            const uint expected = 0x02030405;
             actual.Should().Be(expected);
         }
     }


### PR DESCRIPTION
Also add logs around bad responses from server

This issue causes an intermittent bug where messages from the server get corrupted and silently dropped.