### PR TITLE
Fix partitioned consumer not setting consumer name

### DIFF
--- a/src/DotPulsar/ConsumerOptions.cs
+++ b/src/DotPulsar/ConsumerOptions.cs
@@ -95,6 +95,14 @@ namespace DotPulsar
             AutoUpdatePartitions = options.AutoUpdatePartitions;
             AutoUpdatePartitionsInterval = options.AutoUpdatePartitionsInterval;
             NegativeAcknowledgeRedeliveryDelay = options.NegativeAcknowledgeRedeliveryDelay;
+
+            // Carry consumerName across partitions unless the subscription type is Failover, because Failover sorts by
+            // consumer name to determine the active consumer for a partition.  In the case where this is not desired,
+            // the caller should probably connect a consumer with a set name to each partition manually.
+            if (options.SubscriptionType != SubscriptionType.Failover)
+            {
+                ConsumerName = options.ConsumerName;
+            }
         }
 
         /// <summary>

--- a/src/DotPulsar/Internal/ConsumerChannelFactory.cs
+++ b/src/DotPulsar/Internal/ConsumerChannelFactory.cs
@@ -55,7 +55,7 @@ namespace DotPulsar.Internal
 
             _subscribe = new CommandSubscribe
             {
-                ConsumerName = options.ConsumerName,
+                ConsumerName = options.ConsumerName ?? GenerateRandomConsumerName(),
                 InitialPosition = (CommandSubscribe.InitialPositionType) options.InitialPosition,
                 PriorityLevel = options.PriorityLevel,
                 ReadCompacted = options.ReadCompacted,
@@ -67,6 +67,23 @@ namespace DotPulsar.Internal
             if (options.SubscriptionType == SubscriptionType.KeyShared && options.KeySharedPolicy != null)
             {
                 _subscribe.KeySharedMeta = new KeySharedMeta { allowOutOfOrderDelivery = options.KeySharedPolicy.AllowOutOfOrderDelivery, KeySharedMode = KeySharedMode.AutoSplit };
+            }
+        }
+
+        private static string GenerateRandomConsumerName()
+        {
+            try
+            {
+                using (var rng = System.Security.Cryptography.RandomNumberGenerator.Create())
+                {
+                    var bytes = new byte[4];
+                    rng.GetBytes(bytes);
+                    return BitConverter.ToString(bytes).Replace("-", String.Empty);
+                }
+            }
+            catch
+            {
+                return "";
             }
         }
 

--- a/src/DotPulsar/Internal/ConsumerChannelFactory.cs
+++ b/src/DotPulsar/Internal/ConsumerChannelFactory.cs
@@ -83,7 +83,7 @@ namespace DotPulsar.Internal
             }
             catch
             {
-                return "";
+                return String.Empty;
             }
         }
 


### PR DESCRIPTION
# Summary
Currently, setting a consumer name on a consumer of a partitioned topic does not pass through that name (defaulting to null).  In some cases, such as Key_Shared w/ consistent hashing configured, the consumer name is used to generate hash ring locations, so this is undesirable.  In other cases, such as a Failover subscription, each partition should ideally receive a uniquely generated random name in order to distribute "active" consumer load.
