### PR TITLE
Resolve errors during consumer unload

### DIFF
--- a/src/DotPulsar/Internal/Abstractions/IConsumerChannel.cs
+++ b/src/DotPulsar/Internal/Abstractions/IConsumerChannel.cs
@@ -29,5 +29,6 @@ namespace DotPulsar.Internal.Abstractions
         ValueTask<Message> Receive(CancellationToken cancellationToken);
         void UpdateMessagePrefetchCount(uint messagePrefetchCount, CancellationToken cancellationToken);
         ValueTask NegativeAcknowledge(MessageId messageId, CancellationToken cancellationToken);
+        void ClosedByServer();
     }
 }

--- a/src/DotPulsar/Internal/Connection.cs
+++ b/src/DotPulsar/Internal/Connection.cs
@@ -250,12 +250,12 @@ namespace DotPulsar.Internal
                         switch (command.CommandType)
                         {
                             case BaseCommand.Type.Message:
-                                _channelManager.Incoming(command.Message, new ReadOnlySequence<byte>(frame.Slice(commandSize + 4).ToArray()));
                                 _logger.Trace(nameof(Connection), nameof(ProcessIncommingFrames), "Received Message command from {0} for consumer {1}, MessageId {2}:{3}", Id, command.Message.ConsumerId, command.Message.MessageId.LedgerId, command.Message.MessageId.EntryId);
+                                _channelManager.Incoming(command.Message, new ReadOnlySequence<byte>(frame.Slice(commandSize + 4).ToArray()));
                                 break;
                             case BaseCommand.Type.CloseConsumer:
-                                _channelManager.Incoming(command.CloseConsumer);
                                 _logger.Debug(nameof(Connection), nameof(ProcessIncommingFrames), "Received CloseConsumer command from broker on {0} for consumer {1}", Id, command.CloseConsumer.ConsumerId);
+                                _channelManager.Incoming(command.CloseConsumer);
                                 break;
                             case BaseCommand.Type.ActiveConsumerChange:
                                 _channelManager.Incoming(command.ActiveConsumerChange);
@@ -264,8 +264,8 @@ namespace DotPulsar.Internal
                                 _channelManager.Incoming(command.ReachedEndOfTopic);
                                 break;
                             case BaseCommand.Type.CloseProducer:
-                                _channelManager.Incoming(command.CloseProducer);
                                 _logger.Debug(nameof(Connection), nameof(ProcessIncommingFrames), "Received CloseProducer command from broker on {0} for producer {1}", Id, command.CloseProducer.ProducerId);
+                                _channelManager.Incoming(command.CloseProducer);
                                 // We need to fault all outstanding sends for this producer now also, or else they will hang forever
                                 FaultAllOutstandingSendsForProducer(command.CloseProducer.ProducerId, new ServiceNotReadyException("Broker has closed the producer."));
                                 break;

--- a/src/DotPulsar/Internal/NotReadyChannel.cs
+++ b/src/DotPulsar/Internal/NotReadyChannel.cs
@@ -66,6 +66,11 @@ namespace DotPulsar.Internal
             // no-op
         }
 
+        public void ClosedByServer()
+        {
+            // no-op
+        }
+
         private static Exception GetException()
             => new ChannelNotReadyException();
     }


### PR DESCRIPTION
# Summary

Currently when consumers are unloaded we see errors from the broker because we still try to send CloseConsumer messages for the consumers the broker told us were already closed.  This attempts to avoid sending CloseConsumer in those cases when disposing/replacing the consumer channel.